### PR TITLE
Fix cpuDelta computation for calibration

### DIFF
--- a/public/tracy/TracyTTDevice.hpp
+++ b/public/tracy/TracyTTDevice.hpp
@@ -122,7 +122,7 @@ namespace tracy {
             MemWrite( &item->hdr.type, QueueType::GpuCalibration );
             MemWrite( &item->gpuCalibration.gpuTime, (int64_t)round((double)m_tgpu/m_frequency) );
             MemWrite( &item->gpuCalibration.cpuTime, tcpu );
-            MemWrite( &item->gpuCalibration.cpuDelta, mm_tcpu - tcpu );
+            MemWrite( &item->gpuCalibration.cpuDelta, (int64_t)((tcpu - mm_tcpu) * get_tracy_timer_mul()));
             MemWrite( &item->gpuCalibration.context, GetId() );
             Profiler::QueueSerialFinish();
 


### PR DESCRIPTION
We need to use wall-clock time, not tracy's scaled time, for the cpuDelta field. It is also mentioned in the following:
https://github.com/tenstorrent-metal/tracy/blob/1f635ad3cb584351a07f093528c2fc2e93ec3d52/public/tracy/TracyD3D12.hpp#L92
Besides, the operand order for subtraction was wrong. (mm_tcpu - tcpu results in negative.)

This fix is required for https://github.com/tenstorrent/tt-metal/pull/20742 to work