### PR TITLE
Fix 65536 event limit

### DIFF
--- a/public/tracy/TracyTTDevice.hpp
+++ b/public/tracy/TracyTTDevice.hpp
@@ -153,6 +153,7 @@ namespace tracy {
         tracy_force_inline unsigned int NextQueryId(EventInfo eventInfo)
         {
             const auto id = m_head;
+            if ((m_head + 1) % QueryCount == m_tail) m_tail = m_head;
             m_head = (m_head + 1) % QueryCount;
             TRACY_TT_ASSERT(m_head != m_tail);
             m_query[id] = eventInfo;


### PR DESCRIPTION
In TracyTTDevice.hpp, events are stored in a queue of length 64 * 1024. Implementation for other devices, TracyOpenGL.hpp for example, it has Collect() function that should be periodically called and pops all elements in the queue. However, TTDevice has no such function and triggers the following assert when 65536 elements are pushed.
https://github.com/tenstorrent-metal/tracy/blob/1f635ad3cb584351a07f093528c2fc2e93ec3d52/public/tracy/TracyTTDevice.hpp#L157

Due to this limitation, we are only able to profile two training iterations of GPT2 small, and cannot profile a single iteration of GPT2 large.

This PR fixes this issue: https://github.com/tenstorrent/tt-metal/issues/20801