### PR TITLE
Modified TTDeviceEvent so that it is hashable and < comparisons are faster

### DIFF
--- a/public/common/TracyTTDeviceData.hpp
+++ b/public/common/TracyTTDeviceData.hpp
@@ -84,9 +84,24 @@ namespace tracy
             chip_id = (threadID >> CHIP_BIT_SHIFT) & ((1 << CHIP_BIT_COUNT) - 1);
         }
 
-        friend bool operator<(const TTDeviceEvent& lhs, const TTDeviceEvent& rhs)
-        {
-            return std::tie(lhs.timestamp, lhs.chip_id, lhs.core_x, lhs.core_y, lhs.risc, lhs.marker) < std::tie(rhs.timestamp, rhs.chip_id, rhs.core_x, rhs.core_y, rhs.risc, rhs.marker);
+        friend bool operator<(const TTDeviceEvent& lhs, const TTDeviceEvent& rhs) {
+            ZoneScopedN("operator<");
+            if (lhs.timestamp != rhs.timestamp) {
+                return lhs.timestamp < rhs.timestamp;
+            }
+            if (lhs.chip_id != rhs.chip_id) {
+                return lhs.chip_id < rhs.chip_id;
+            }
+            if (lhs.core_x != rhs.core_x) {
+                return lhs.core_x < rhs.core_x;
+            }
+            if (lhs.core_y != rhs.core_y) {
+                return lhs.core_y < rhs.core_y;
+            }
+            if (lhs.risc != rhs.risc) {
+                return lhs.risc < rhs.risc;
+            }
+            return lhs.marker < rhs.marker;
         }
 
         uint64_t get_thread_id() const
@@ -99,7 +114,22 @@ namespace tracy
             return threadID;
         }
     };
-
-
 }
+
+namespace std {
+template <>
+struct hash<tracy::TTDeviceEvent> {
+    std::size_t operator()(const tracy::TTDeviceEvent& obj) const {
+        std::hash<uint64_t> hasher;
+        std::size_t hash_value = 0;
+        hash_value ^= hasher(obj.timestamp) + 0x9e3779b9 + (hash_value << 6) + (hash_value >> 2);
+        hash_value ^= hasher(obj.chip_id) + 0x9e3779b9 + (hash_value << 6) + (hash_value >> 2);
+        hash_value ^= hasher(obj.core_x) + 0x9e3779b9 + (hash_value << 6) + (hash_value >> 2);
+        hash_value ^= hasher(obj.core_y) + 0x9e3779b9 + (hash_value << 6) + (hash_value >> 2);
+        hash_value ^= hasher(obj.risc) + 0x9e3779b9 + (hash_value << 6) + (hash_value >> 2);
+        hash_value ^= hasher(obj.marker) + 0x9e3779b9 + (hash_value << 6) + (hash_value >> 2);
+        return hash_value;
+    }
+};
+}  // namespace std
 #endif

--- a/public/common/TracyTTDeviceData.hpp
+++ b/public/common/TracyTTDeviceData.hpp
@@ -1,6 +1,8 @@
 #ifndef __TRACYTTDEVICEDATA_HPP__
 #define __TRACYTTDEVICEDATA_HPP__
 
+#include "tracy/Tracy.hpp"
+
 namespace tracy
 {
     static std::string riscName[] = {"BRISC", "NCRISC", "TRISC_0", "TRISC_1", "TRISC_2", "ERISC"};
@@ -102,6 +104,12 @@ namespace tracy
                 return lhs.risc < rhs.risc;
             }
             return lhs.marker < rhs.marker;
+        }
+
+        friend bool operator==(const TTDeviceEvent& lhs, const TTDeviceEvent& rhs) {
+            ZoneScopedN("operator==");
+            return lhs.timestamp == rhs.timestamp && lhs.chip_id == rhs.chip_id && lhs.core_x == rhs.core_x &&
+                   lhs.core_y == rhs.core_y && lhs.risc == rhs.risc && lhs.marker == rhs.marker;
         }
 
         uint64_t get_thread_id() const

--- a/public/common/TracyTTDeviceData.hpp
+++ b/public/common/TracyTTDeviceData.hpp
@@ -1,8 +1,6 @@
 #ifndef __TRACYTTDEVICEDATA_HPP__
 #define __TRACYTTDEVICEDATA_HPP__
 
-#include "tracy/Tracy.hpp"
-
 namespace tracy
 {
     static std::string riscName[] = {"BRISC", "NCRISC", "TRISC_0", "TRISC_1", "TRISC_2", "ERISC"};
@@ -87,7 +85,6 @@ namespace tracy
         }
 
         friend bool operator<(const TTDeviceEvent& lhs, const TTDeviceEvent& rhs) {
-            ZoneScopedN("operator<");
             if (lhs.timestamp != rhs.timestamp) {
                 return lhs.timestamp < rhs.timestamp;
             }

--- a/public/common/TracyTTDeviceData.hpp
+++ b/public/common/TracyTTDeviceData.hpp
@@ -126,12 +126,13 @@ struct hash<tracy::TTDeviceEvent> {
     std::size_t operator()(const tracy::TTDeviceEvent& obj) const {
         std::hash<uint64_t> hasher;
         std::size_t hash_value = 0;
-        hash_value ^= hasher(obj.timestamp) + 0x9e3779b9 + (hash_value << 6) + (hash_value >> 2);
-        hash_value ^= hasher(obj.chip_id) + 0x9e3779b9 + (hash_value << 6) + (hash_value >> 2);
-        hash_value ^= hasher(obj.core_x) + 0x9e3779b9 + (hash_value << 6) + (hash_value >> 2);
-        hash_value ^= hasher(obj.core_y) + 0x9e3779b9 + (hash_value << 6) + (hash_value >> 2);
-        hash_value ^= hasher(obj.risc) + 0x9e3779b9 + (hash_value << 6) + (hash_value >> 2);
-        hash_value ^= hasher(obj.marker) + 0x9e3779b9 + (hash_value << 6) + (hash_value >> 2);
+        constexpr std::size_t hash_combine_prime = 0x9e3779b9;
+        hash_value ^= hasher(obj.timestamp) + hash_combine_prime + (hash_value << 6) + (hash_value >> 2);
+        hash_value ^= hasher(obj.chip_id) + hash_combine_prime + (hash_value << 6) + (hash_value >> 2);
+        hash_value ^= hasher(obj.core_x) + hash_combine_prime + (hash_value << 6) + (hash_value >> 2);
+        hash_value ^= hasher(obj.core_y) + hash_combine_prime + (hash_value << 6) + (hash_value >> 2);
+        hash_value ^= hasher(obj.risc) + hash_combine_prime + (hash_value << 6) + (hash_value >> 2);
+        hash_value ^= hasher(obj.marker) + hash_combine_prime + (hash_value << 6) + (hash_value >> 2);
         return hash_value;
     }
 };

--- a/public/common/TracyTTDeviceData.hpp
+++ b/public/common/TracyTTDeviceData.hpp
@@ -107,7 +107,6 @@ namespace tracy
         }
 
         friend bool operator==(const TTDeviceEvent& lhs, const TTDeviceEvent& rhs) {
-            ZoneScopedN("operator==");
             return lhs.timestamp == rhs.timestamp && lhs.chip_id == rhs.chip_id && lhs.core_x == rhs.core_x &&
                    lhs.core_y == rhs.core_y && lhs.risc == rhs.risc && lhs.marker == rhs.marker;
         }


### PR DESCRIPTION
This PR modifies TTDeviceEvent to be hashable by adding a hash function and an == comparator function, and it also modifies the existing < comparator function to use manual if-else branching instead of `std::tie` to improve performance.