### PR TITLE
Renamed TTDeviceEvent::marker variable to TTDeviceEvent::timer_id and moved logic for determining zone colour to tt_metal

### DIFF
--- a/public/common/TracyTTDeviceData.hpp
+++ b/public/common/TracyTTDeviceData.hpp
@@ -3,7 +3,53 @@
 
 namespace tracy
 {
-    static std::string riscName[] = {"BRISC", "NCRISC", "TRISC_0", "TRISC_1", "TRISC_2", "ERISC"};
+    inline std::string riscName[] = {"BRISC", "NCRISC", "TRISC_0", "TRISC_1", "TRISC_2", "ERISC"};
+
+    enum class TTDeviceEventZoneNameKeyword : uint16_t {
+        BRISC_FW = 1,
+        ERISC_FW = 2,
+        SYNC_ZONE = 4,
+        PROFILER = 8,
+        DISPATCH = 16,
+        PROCESS_CMD = 32,
+        RUNTIME_HOST_ID_DISPATCH = 64,
+        PACKED_DATA_DISPATCH = 128,
+        PACKED_LARGE_DATA_DISPATCH = 256
+    };
+
+    inline std::unordered_map<std::string, TTDeviceEventZoneNameKeyword> zoneNameKeywordsMap = {
+        {"BRISC-FW", TTDeviceEventZoneNameKeyword::BRISC_FW},
+        {"ERISC-FW", TTDeviceEventZoneNameKeyword::ERISC_FW},
+        {"SYNC-ZONE", TTDeviceEventZoneNameKeyword::SYNC_ZONE},
+        {"PROFILER", TTDeviceEventZoneNameKeyword::PROFILER},
+        {"DISPATCH", TTDeviceEventZoneNameKeyword::DISPATCH},
+        {"process_cmd", TTDeviceEventZoneNameKeyword::PROCESS_CMD},
+        {"runtime_host_id_dispatch", TTDeviceEventZoneNameKeyword::RUNTIME_HOST_ID_DISPATCH},
+        {"packed_data_dispatch", TTDeviceEventZoneNameKeyword::PACKED_DATA_DISPATCH},
+        {"packed_large_data_dispatch", TTDeviceEventZoneNameKeyword::PACKED_LARGE_DATA_DISPATCH},
+    };
+
+    inline bool hasZoneNameKeyword(uint16_t zone_name_keywords_mask, TTDeviceEventZoneNameKeyword keyword) {
+        return (zone_name_keywords_mask & static_cast<uint16_t>(keyword)) != 0;
+    }
+
+    // inline uint16_t addZoneNameKeywordToMask(uint16_t zone_name_keywords_mask, TTDeviceEventZoneNameKeyword keyword) {
+    //     return zone_name_keywords_mask | static_cast<uint16_t>(keyword);
+    // }
+
+    // inline uint16_t removeZoneNameKeywordFromMask(uint16_t zone_name_keywords_mask, TTDeviceEventZoneNameKeyword keyword) {
+    //     return zone_name_keywords_mask & ~static_cast<uint16_t>(keyword);
+    // }
+
+    inline uint16_t generateZoneNameKeywordsMask(const std::string& zone_name) {
+        uint16_t mask = 0;
+        for (const auto& [key, value] : zoneNameKeywordsMap) {
+            if (zone_name.find(key) != std::string::npos) {
+                mask |= static_cast<uint16_t>(value);
+            }
+        }
+        return mask;
+    }
 
     enum TTDeviceEventPhase
     {
@@ -43,6 +89,7 @@ namespace tracy
         uint64_t line;
         std::string file;
         std::string zone_name;
+        uint16_t zone_name_keywords_mask;
         TTDeviceEventPhase zone_phase;
 
         TTDeviceEvent (): 
@@ -56,25 +103,36 @@ namespace tracy
             line(INVALID_NUM),
             file(""),
             zone_name(""),
+            zone_name_keywords_mask(0),
             zone_phase(begin)
         {
         }
 
-        TTDeviceEvent (
-                uint64_t run_num,
-                uint64_t chip_id,
-                uint64_t core_x,
-                uint64_t core_y,
-                uint64_t risc,
-                uint64_t marker,
-                uint64_t timestamp,
-                uint64_t line,
-                std::string file,
-                std::string zone_name,
-                TTDeviceEventPhase zone_phase
-                ): run_num(run_num),chip_id(chip_id),core_x(core_x),core_y(core_y),risc(risc),marker(marker),timestamp(timestamp),line(line),file(file),zone_name(zone_name),zone_phase(zone_phase)
-        {
-        }
+        TTDeviceEvent(
+            uint64_t run_num,
+            uint64_t chip_id,
+            uint64_t core_x,
+            uint64_t core_y,
+            uint64_t risc,
+            uint64_t marker,
+            uint64_t timestamp,
+            uint64_t line,
+            std::string file,
+            std::string zone_name,
+            uint16_t zone_name_keywords_mask,
+            TTDeviceEventPhase zone_phase) :
+            run_num(run_num),
+            chip_id(chip_id),
+            core_x(core_x),
+            core_y(core_y),
+            risc(risc),
+            marker(marker),
+            timestamp(timestamp),
+            line(line),
+            file(file),
+            zone_name(zone_name),
+            zone_name_keywords_mask(zone_name_keywords_mask),
+            zone_phase(zone_phase) {}
 
         TTDeviceEvent (uint64_t threadID) :run_num(-1),marker(-1)
         {

--- a/public/common/TracyTTDeviceData.hpp
+++ b/public/common/TracyTTDeviceData.hpp
@@ -33,14 +33,6 @@ namespace tracy
         return (zone_name_keywords_mask & static_cast<uint16_t>(keyword)) != 0;
     }
 
-    // inline uint16_t addZoneNameKeywordToMask(uint16_t zone_name_keywords_mask, TTDeviceEventZoneNameKeyword keyword) {
-    //     return zone_name_keywords_mask | static_cast<uint16_t>(keyword);
-    // }
-
-    // inline uint16_t removeZoneNameKeywordFromMask(uint16_t zone_name_keywords_mask, TTDeviceEventZoneNameKeyword keyword) {
-    //     return zone_name_keywords_mask & ~static_cast<uint16_t>(keyword);
-    // }
-
     inline uint16_t generateZoneNameKeywordsMask(const std::string& zone_name) {
         uint16_t mask = 0;
         for (const auto& [key, value] : zoneNameKeywordsMap) {
@@ -50,11 +42,6 @@ namespace tracy
         }
         return mask;
     }
-
-    struct TTDeviceEventLinearRegressionParams {
-        double freq_scale = 1.0;
-        int64_t shift = 0;
-    };
 
     enum TTDeviceEventPhase
     {

--- a/public/common/TracyTTDeviceData.hpp
+++ b/public/common/TracyTTDeviceData.hpp
@@ -51,6 +51,11 @@ namespace tracy
         return mask;
     }
 
+    struct TTDeviceEventLinearRegressionParams {
+        double freq_scale = 1.0;
+        int64_t shift = 0;
+    };
+
     enum TTDeviceEventPhase
     {
         begin,

--- a/public/tracy/TracyTTDevice.hpp
+++ b/public/tracy/TracyTTDevice.hpp
@@ -179,16 +179,10 @@ namespace tracy {
 
             const auto queryId = this->NextQueryId(EventInfo{ event, EventPhase::Begin });
 
-            int color;
-
-            if (event.zone_name.find("PROFILER") != std::string::npos)
-            {
-                color = tracy::Color::Tomato3;
-            }
-            else
-            {
-                color = customColors[event.risc % customColors.size()];
-            }
+            const uint32_t color =
+                (hasZoneNameKeyword(event.zone_name_keywords_mask, TTDeviceEventZoneNameKeyword::PROFILER))
+                    ? tracy::Color::Tomato3
+                    : customColors[event.risc % customColors.size()];
 
             std::string run_id_string = "";
             if (event.run_num > 0)

--- a/public/tracy/TracyTTDevice.hpp
+++ b/public/tracy/TracyTTDevice.hpp
@@ -7,8 +7,8 @@
 #define TracyTTDestroy(c)
 #define TracyTTContextName(c, x, y)
 #define TracyTTContextPopulate(c, x, y, z)
-#define TracyTTPushStartZone(c, e)
-#define TracyTTPushEndZone(c, e)
+#define TracyTTPushStartZone(c, e, p)
+#define TracyTTPushEndZone(c, e, p)
 
 #define TracyGetTimerMul() 0
 #define TracyGetBaseTime() 0
@@ -166,18 +166,17 @@ namespace tracy {
             return m_query[id];
         }
 
-        void PushStartZone (const TTDeviceEvent& event)
-        {
-            constexpr std::array<int,6> customColors = {
+        void PushStartZone(
+            const TTDeviceEvent& event, const TTDeviceEventLinearRegressionParams& eventLinearRegressionParams) {
+            constexpr std::array<int, 6> customColors = {
                 tracy::Color::Orange2,
                 tracy::Color::SeaGreen3,
                 tracy::Color::SkyBlue3,
                 tracy::Color::Turquoise2,
                 tracy::Color::CadetBlue1,
-                tracy::Color::Yellow3
-            };
+                tracy::Color::Yellow3};
 
-            const auto queryId = this->NextQueryId(EventInfo{ event, EventPhase::Begin });
+            const auto queryId = this->NextQueryId(EventInfo{event, EventPhase::Begin});
 
             const uint32_t color =
                 (hasZoneNameKeyword(event.zone_name_keywords_mask, TTDeviceEventZoneNameKeyword::PROFILER))
@@ -185,20 +184,19 @@ namespace tracy {
                     : customColors[event.risc % customColors.size()];
 
             std::string run_id_string = "";
-            if (event.run_num > 0)
-            {
+            if (event.run_num > 0) {
                 run_id_string = "OP ID:" + std::to_string(event.run_num);
             }
 
             const auto srcloc = Profiler::AllocSourceLocation(
-                    event.line,
-                    event.file.c_str(),
-                    event.file.length(),
-                    run_id_string.c_str(),
-                    run_id_string.length(),
-                    event.zone_name.c_str(),
-                    event.zone_name.length(),
-                    color);
+                event.line,
+                event.file.c_str(),
+                event.file.length(),
+                run_id_string.c_str(),
+                run_id_string.length(),
+                event.zone_name.c_str(),
+                event.zone_name.length(),
+                color);
 
             auto zoneBegin = Profiler::QueueSerial();
             MemWrite(&zoneBegin->hdr.type, QueueType::GpuZoneBeginAllocSrcLocSerial);
@@ -211,15 +209,20 @@ namespace tracy {
 
             auto zoneTime = Profiler::QueueSerial();
             MemWrite(&zoneTime->hdr.type, QueueType::GpuTime);
-            MemWrite(&zoneTime->gpuTime.gpuTime, (uint64_t)round((double)event.timestamp/m_frequency));
+            MemWrite(
+                &zoneTime->gpuTime.gpuTime,
+                (uint64_t)round(
+                    (double)(event.timestamp * eventLinearRegressionParams.freq_scale +
+                             eventLinearRegressionParams.shift) /
+                    m_frequency));
             MemWrite(&zoneTime->gpuTime.queryId, (uint16_t)queryId);
             MemWrite(&zoneTime->gpuTime.context, this->GetId());
             Profiler::QueueSerialFinish();
         }
 
-        void PushEndZone (const TTDeviceEvent& event)
-        {
-            const auto queryId = this->NextQueryId(EventInfo{ event, EventPhase::End });
+        void PushEndZone(
+            const TTDeviceEvent& event, const TTDeviceEventLinearRegressionParams& eventLinearRegressionParams) {
+            const auto queryId = this->NextQueryId(EventInfo{event, EventPhase::End});
 
             auto zoneEnd = Profiler::QueueSerial();
             MemWrite(&zoneEnd->hdr.type, QueueType::GpuZoneEndSerial);
@@ -228,10 +231,15 @@ namespace tracy {
             MemWrite(&zoneEnd->gpuZoneEnd.queryId, (uint16_t)queryId);
             MemWrite(&zoneEnd->gpuZoneEnd.context, this->GetId());
             Profiler::QueueSerialFinish();
-            
+
             auto zoneTime = Profiler::QueueSerial();
             MemWrite(&zoneTime->hdr.type, QueueType::GpuTime);
-            MemWrite(&zoneTime->gpuTime.gpuTime, (uint64_t)round((double)event.timestamp/m_frequency));
+            MemWrite(
+                &zoneTime->gpuTime.gpuTime,
+                (uint64_t)round(
+                    (double)(event.timestamp * eventLinearRegressionParams.freq_scale +
+                             eventLinearRegressionParams.shift) /
+                    m_frequency));
             MemWrite(&zoneTime->gpuTime.queryId, (uint16_t)queryId);
             MemWrite(&zoneTime->gpuTime.context, this->GetId());
             Profiler::QueueSerialFinish();
@@ -273,8 +281,8 @@ using TracyTTCtx = tracy::TTCtx*;
 #define TracyTTContextName(ctx, name, size) ctx->Name(name, size)
 #define TracyTTContextPopulate(ctx, cpuTime, timeshift, frequency) ctx->PopulateTTContext(cpuTime, timeshift, frequency)
 #define TracyTTContextCalibrate(ctx, cpuTime, timeshift, frequency) ctx->CalibrateTTContext(cpuTime, timeshift, frequency)
-#define TracyTTPushStartZone(ctx, event) ctx->PushStartZone(event)
-#define TracyTTPushEndZone(ctx, event) ctx->PushEndZone(event)
+#define TracyTTPushStartZone(ctx, event, linearRegressionParams) ctx->PushStartZone(event, linearRegressionParams)
+#define TracyTTPushEndZone(ctx, event, linearRegressionParams) ctx->PushEndZone(event, linearRegressionParams)
 
 #define TracyGetTimerMul() tracy::get_tracy_timer_mul()
 #define TracyGetBaseTime() tracy::get_tracy_base_time()

--- a/public/tracy/TracyTTDevice.hpp
+++ b/public/tracy/TracyTTDevice.hpp
@@ -168,20 +168,7 @@ namespace tracy {
 
         void PushStartZone(
             const TTDeviceEvent& event) {
-            constexpr std::array<int, 6> customColors = {
-                tracy::Color::Orange2,
-                tracy::Color::SeaGreen3,
-                tracy::Color::SkyBlue3,
-                tracy::Color::Turquoise2,
-                tracy::Color::CadetBlue1,
-                tracy::Color::Yellow3};
-
             const auto queryId = this->NextQueryId(EventInfo{event, EventPhase::Begin});
-
-            const uint32_t color =
-                (hasZoneNameKeyword(event.zone_name_keywords_mask, TTDeviceEventZoneNameKeyword::PROFILER))
-                    ? tracy::Color::Tomato3
-                    : customColors[event.risc % customColors.size()];
 
             const std::string run_id_string = event.run_num > 0 ? "OP ID:" + std::to_string(event.run_num) : "";
 
@@ -193,7 +180,7 @@ namespace tracy {
                 run_id_string.length(),
                 event.zone_name.c_str(),
                 event.zone_name.length(),
-                color);
+                event.color);
 
             auto zoneBegin = Profiler::QueueSerial();
             MemWrite(&zoneBegin->hdr.type, QueueType::GpuZoneBeginAllocSrcLocSerial);


### PR DESCRIPTION
This PR adds a bitmask for zone names that keeps track of important keywords found within the names. This reduces the number of expensive substring searches we need to do as we can just see whether the corresponding bit for the word we're searching for is in the bitmask.