### PR TITLE
Add connect timeout to bound buffered profiling memory

### DIFF
--- a/public/client/TracyProfiler.cpp
+++ b/public/client/TracyProfiler.cpp
@@ -1467,6 +1467,7 @@ Profiler::Profiler()
     , m_broadcast( nullptr )
     , m_noExit( false )
     , m_userPort( 0 )
+    , m_connectTimeout( std::chrono::seconds( 60 ) )
     , m_zoneId( 1 )
     , m_samplingPeriod( 0 )
     , m_stream( LZ4_createStream() )
@@ -1483,6 +1484,7 @@ Profiler::Profiler()
     , m_symbolQueue( 8*1024 )
     , m_frameCount( 0 )
     , m_isConnected( false )
+    , m_emitSuppressed( false )
 #ifdef TRACY_ON_DEMAND
     , m_connectionId( 0 )
     , m_symbolsBusy( false )
@@ -1528,6 +1530,19 @@ Profiler::Profiler()
     if( userPort )
     {
         m_userPort = atoi( userPort );
+    }
+
+    // Seconds before an unconnected client drops its buffered backlog and stops recording; 0 disables.
+    const char* connectTimeout = GetEnvVar( "TRACY_CONNECT_TIMEOUT" );
+    if( connectTimeout )
+    {
+        char* end;
+        const auto seconds = strtoll( connectTimeout, &end, 10 );
+        constexpr int64_t maxSeconds = std::chrono::nanoseconds::max().count() / 1'000'000'000;
+        if( end != connectTimeout && *end == '\0' && seconds >= 0 && seconds <= maxSeconds )
+        {
+            m_connectTimeout = std::chrono::seconds( seconds );
+        }
     }
 
     m_safeSendBuffer = (char*)tracy_malloc( SafeSendBufferSize );
@@ -1840,6 +1855,8 @@ void Profiler::Worker()
     }
     if( !isListening )
     {
+        // No listen socket bound: nothing can ever connect to drain the queues, so never buffer.
+        SuppressEmit();
         for(;;)
         {
             if( ShouldExit() )
@@ -1879,6 +1896,11 @@ void Profiler::Worker()
     auto& broadcastMsg = GetBroadcastMessage( procname, pnsz, broadcastLen, dataPort );
     uint64_t lastBroadcast = 0;
 
+#ifndef TRACY_ON_DEMAND
+    const auto waitStart = std::chrono::steady_clock::now();
+    bool connectRefusedWarned = false;
+#endif
+
     // Connections loop.
     // Each iteration of the loop handles whole connection. Multiple iterations will only
     // happen in the on-demand mode or when handshake fails.
@@ -1901,11 +1923,22 @@ void Profiler::Worker()
 #endif
             m_sock = listen.Accept();
             if( m_sock ) break;
+
 #ifndef TRACY_ON_DEMAND
-            ProcessSysTime();
+            if( m_connectTimeout.count() > 0 && !IsEmitSuppressed() &&
+                std::chrono::steady_clock::now() - waitStart > m_connectTimeout )
+            {
+                // Connect window lapsed with no client: drop the backlog and stop buffering (later connects are refused).
+                SuppressEmit();
+                ClearQueues( token );
+            }
+            if( !IsEmitSuppressed() )
+            {
+                ProcessSysTime();
 #  ifdef TRACY_HAS_SYSPOWER
-            m_sysPower.Tick();
+                m_sysPower.Tick();
 #  endif
+            }
 #endif
 
             if( m_broadcast )
@@ -1969,6 +2002,24 @@ void Profiler::Worker()
                 continue;
             }
         }
+
+#ifndef TRACY_ON_DEMAND
+        if( IsEmitSuppressed() )
+        {
+            HandshakeStatus status = HandshakeNotAvailable;
+            m_sock->Send( &status, sizeof( status ) );
+            m_sock->~Socket();
+            tracy_free( m_sock );
+            m_sock = nullptr;
+            if( !connectRefusedWarned )
+            {
+                connectRefusedWarned = true;
+                fprintf( stderr, "Tracy Profiler connect timeout: connection refused; no client connected within the %lld s window.\n",
+                    (long long)std::chrono::duration_cast<std::chrono::seconds>( m_connectTimeout ).count() );
+            }
+            continue;
+        }
+#endif
 
 #ifdef TRACY_ON_DEMAND
         while( m_symbolsBusy.load( std::memory_order_acquire ) ) { YieldThread(); }
@@ -2094,6 +2145,7 @@ void Profiler::Worker()
 
 #ifndef TRACY_ON_DEMAND
         // Client is no longer available here. Accept incoming connections, but reject handshake.
+        SuppressEmit();
         for(;;)
         {
             if( ShouldExit() )
@@ -4463,11 +4515,7 @@ extern "C" {
 TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_location_data* srcloc, int32_t active )
 {
     ___tracy_c_zone_context ctx;
-#ifdef TRACY_ON_DEMAND
-    ctx.active = active && tracy::GetProfiler().IsConnected();
-#else
-    ctx.active = active;
-#endif
+    ctx.active = active && !tracy::GetProfiler().IsEmitSuppressed();
     if( !ctx.active ) return ctx;
     const auto id = tracy::GetProfiler().GetNextZoneId();
     ctx.id = id;
@@ -4491,11 +4539,7 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin( const struct ___tracy_source_l
 TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___tracy_source_location_data* srcloc, int32_t depth, int32_t active )
 {
     ___tracy_c_zone_context ctx;
-#ifdef TRACY_ON_DEMAND
-    ctx.active = active && tracy::GetProfiler().IsConnected();
-#else
-    ctx.active = active;
-#endif
+    ctx.active = active && !tracy::GetProfiler().IsEmitSuppressed();
     if( !ctx.active ) return ctx;
     const auto id = tracy::GetProfiler().GetNextZoneId();
     ctx.id = id;
@@ -4524,11 +4568,7 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_callstack( const struct ___trac
 TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int32_t active )
 {
     ___tracy_c_zone_context ctx;
-#ifdef TRACY_ON_DEMAND
-    ctx.active = active && tracy::GetProfiler().IsConnected();
-#else
-    ctx.active = active;
-#endif
+    ctx.active = active && !tracy::GetProfiler().IsEmitSuppressed();
     if( !ctx.active )
     {
         tracy::tracy_free( (void*)srcloc );
@@ -4556,11 +4596,7 @@ TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc( uint64_t srcloc, int32_t
 TRACY_API TracyCZoneCtx ___tracy_emit_zone_begin_alloc_callstack( uint64_t srcloc, int32_t depth, int32_t active )
 {
     ___tracy_c_zone_context ctx;
-#ifdef TRACY_ON_DEMAND
-    ctx.active = active && tracy::GetProfiler().IsConnected();
-#else
-    ctx.active = active;
-#endif
+    ctx.active = active && !tracy::GetProfiler().IsEmitSuppressed();
     if( !ctx.active )
     {
         tracy::tracy_free( (void*)srcloc );

--- a/public/client/TracyProfiler.hpp
+++ b/public/client/TracyProfiler.hpp
@@ -3,6 +3,7 @@
 
 #include <assert.h>
 #include <atomic>
+#include <chrono>
 #include <condition_variable>
 #include <stdint.h>
 #include <string.h>
@@ -340,9 +341,7 @@ public:
     static tracy_force_inline void SendFrameMark( const char* name )
     {
         if( !name ) GetProfiler().m_frameCount.fetch_add( 1, std::memory_order_relaxed );
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
+        if( GetProfiler().IsEmitSuppressed() ) return;
         auto item = QueueSerial();
         MemWrite( &item->hdr.type, QueueType::FrameMarkMsg );
         MemWrite( &item->frameMark.time, GetTime() );
@@ -353,9 +352,7 @@ public:
     static tracy_force_inline void SendFrameMark( const char* name, QueueType type )
     {
         assert( type == QueueType::FrameMarkMsgStart || type == QueueType::FrameMarkMsgEnd );
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
+        if( GetProfiler().IsEmitSuppressed() ) return;
         auto item = QueueSerial();
         MemWrite( &item->hdr.type, type );
         MemWrite( &item->frameMark.time, GetTime() );
@@ -368,9 +365,7 @@ public:
 #ifndef TRACY_NO_FRAME_IMAGE
         auto& profiler = GetProfiler();
         assert( profiler.m_frameCount.load( std::memory_order_relaxed ) < (std::numeric_limits<uint32_t>::max)() );
-#  ifdef TRACY_ON_DEMAND
-        if( !profiler.IsConnected() ) return;
-#  endif
+        if( profiler.IsEmitSuppressed() ) return;
         const auto sz = size_t( w ) * size_t( h ) * 4;
         auto ptr = (char*)tracy_malloc( sz );
         memcpy( ptr, image, sz );
@@ -395,9 +390,7 @@ public:
 
     static tracy_force_inline void PlotData( const char* name, int64_t val )
     {
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
+        if( GetProfiler().IsEmitSuppressed() ) return;
         TracyLfqPrepare( QueueType::PlotDataInt );
         MemWrite( &item->plotDataInt.name, (uint64_t)name );
         MemWrite( &item->plotDataInt.time, GetTime() );
@@ -407,9 +400,7 @@ public:
 
     static tracy_force_inline void PlotData( const char* name, float val )
     {
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
+        if( GetProfiler().IsEmitSuppressed() ) return;
         TracyLfqPrepare( QueueType::PlotDataFloat );
         MemWrite( &item->plotDataFloat.name, (uint64_t)name );
         MemWrite( &item->plotDataFloat.time, GetTime() );
@@ -419,9 +410,7 @@ public:
 
     static tracy_force_inline void PlotData( const char* name, double val )
     {
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
+        if( GetProfiler().IsEmitSuppressed() ) return;
         TracyLfqPrepare( QueueType::PlotDataDouble );
         MemWrite( &item->plotDataDouble.name, (uint64_t)name );
         MemWrite( &item->plotDataDouble.time, GetTime() );
@@ -448,9 +437,7 @@ public:
     static tracy_force_inline void LogString( MessageSourceType source, MessageSeverity severity, uint32_t color, int32_t callstack_depth, size_t txtLength, const char* txt )
     {
         assert( txtLength < (std::numeric_limits<uint16_t>::max)() );
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
+        if( GetProfiler().IsEmitSuppressed() ) return;
         if( callstack_depth != 0 && has_callstack() )
         {
             tracy::GetProfiler().SendCallstack( callstack_depth );
@@ -483,9 +470,7 @@ public:
 
     static tracy_force_inline void LogString( MessageSourceType source, MessageSeverity severity, uint32_t color, int32_t callstack_depth, const char* txt )
     {
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
+        if( GetProfiler().IsEmitSuppressed() ) return;
         if( callstack_depth != 0 && has_callstack() )
         {
             tracy::GetProfiler().SendCallstack( callstack_depth );
@@ -535,9 +520,7 @@ public:
     static tracy_force_inline void MemAlloc( const void* ptr, size_t size, bool secure )
     {
         if( secure && !ProfilerAvailable() ) return;
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
+        if( GetProfiler().IsEmitSuppressed() ) return;
         const auto thread = GetThreadHandle();
 
         GetProfiler().m_serialLock.lock();
@@ -548,9 +531,7 @@ public:
     static tracy_force_inline void MemFree( const void* ptr, bool secure )
     {
         if( secure && !ProfilerAvailable() ) return;
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
+        if( GetProfiler().IsEmitSuppressed() ) return;
         const auto thread = GetThreadHandle();
 
         GetProfiler().m_serialLock.lock();
@@ -564,9 +545,7 @@ public:
         if( depth > 0 && has_callstack() )
         {
             auto& profiler = GetProfiler();
-#  ifdef TRACY_ON_DEMAND
-            if( !profiler.IsConnected() ) return;
-#  endif
+            if( profiler.IsEmitSuppressed() ) return;
             const auto thread = GetThreadHandle();
 
             auto callstack = Callstack( depth );
@@ -593,9 +572,7 @@ public:
         if( depth > 0 && has_callstack() )
         {
             auto& profiler = GetProfiler();
-#  ifdef TRACY_ON_DEMAND
-            if( !profiler.IsConnected() ) return;
-#  endif
+            if( profiler.IsEmitSuppressed() ) return;
             const auto thread = GetThreadHandle();
 
             auto callstack = Callstack( depth );
@@ -614,9 +591,7 @@ public:
     static tracy_force_inline void MemAllocNamed( const void* ptr, size_t size, bool secure, const char* name )
     {
         if( secure && !ProfilerAvailable() ) return;
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
+        if( GetProfiler().IsEmitSuppressed() ) return;
         const auto thread = GetThreadHandle();
 
         GetProfiler().m_serialLock.lock();
@@ -628,9 +603,7 @@ public:
     static tracy_force_inline void MemFreeNamed( const void* ptr, bool secure, const char* name )
     {
         if( secure && !ProfilerAvailable() ) return;
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
+        if( GetProfiler().IsEmitSuppressed() ) return;
         const auto thread = GetThreadHandle();
 
         GetProfiler().m_serialLock.lock();
@@ -645,9 +618,7 @@ public:
         if( depth > 0 && has_callstack() )
         {
             auto& profiler = GetProfiler();
-#  ifdef TRACY_ON_DEMAND
-            if( !profiler.IsConnected() ) return;
-#  endif
+            if( profiler.IsEmitSuppressed() ) return;
             const auto thread = GetThreadHandle();
 
             auto callstack = Callstack( depth );
@@ -670,9 +641,7 @@ public:
         if( depth > 0 && has_callstack() )
         {
             auto& profiler = GetProfiler();
-#  ifdef TRACY_ON_DEMAND
-            if( !profiler.IsConnected() ) return;
-#  endif
+            if( profiler.IsEmitSuppressed() ) return;
             const auto thread = GetThreadHandle();
 
             auto callstack = Callstack( depth );
@@ -692,9 +661,7 @@ public:
     static tracy_force_inline void MemDiscard( const char* name, bool secure )
     {
         if( secure && !ProfilerAvailable() ) return;
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
+        if( GetProfiler().IsEmitSuppressed() ) return;
         const auto thread = GetThreadHandle();
 
         GetProfiler().m_serialLock.lock();
@@ -707,9 +674,7 @@ public:
         if( secure && !ProfilerAvailable() ) return;
         if( depth > 0 && has_callstack() )
         {
-#  ifdef TRACY_ON_DEMAND
-            if( !GetProfiler().IsConnected() ) return;
-#  endif
+            if( GetProfiler().IsEmitSuppressed() ) return;
             const auto thread = GetThreadHandle();
 
             auto callstack = Callstack( depth );
@@ -768,9 +733,7 @@ public:
 #ifdef TRACY_FIBERS
     static tracy_force_inline void EnterFiber( const char* fiber, int32_t groupHint )
     {
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
+        if( GetProfiler().IsEmitSuppressed() ) return;
         TracyQueuePrepare( QueueType::FiberEnter );
         MemWrite( &item->fiberEnter.time, GetTime() );
         MemWrite( &item->fiberEnter.fiber, (uint64_t)fiber );
@@ -780,9 +743,7 @@ public:
 
     static tracy_force_inline void LeaveFiber()
     {
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() ) return;
-#endif
+        if( GetProfiler().IsEmitSuppressed() ) return;
         TracyQueuePrepare( QueueType::FiberLeave );
         MemWrite( &item->fiberLeave.time, GetTime() );
         TracyQueueCommit( fiberLeave );
@@ -798,6 +759,18 @@ public:
     {
         return m_isConnected.load( std::memory_order_acquire );
     }
+
+    // Producer emission gate: suppressed once the connect-timeout grace window lapses or if the server is not connected in on-demand mode.
+    tracy_force_inline bool IsEmitSuppressed() const
+    {
+#ifdef TRACY_ON_DEMAND
+        return !IsConnected();
+#else
+        return m_emitSuppressed.load( std::memory_order_relaxed );
+#endif
+    }
+
+    tracy_force_inline void SuppressEmit() { m_emitSuppressed.store( true, std::memory_order_relaxed ); }
 
     tracy_force_inline void SetProgramName( const char* name )
     {
@@ -1056,6 +1029,7 @@ private:
     UdpBroadcast* m_broadcast;
     bool m_noExit;
     uint32_t m_userPort;
+    std::chrono::nanoseconds m_connectTimeout;
     std::atomic<uint32_t> m_zoneId;
     int64_t m_samplingPeriod;
 
@@ -1086,6 +1060,7 @@ private:
 
     std::atomic<uint64_t> m_frameCount;
     std::atomic<bool> m_isConnected;
+    std::atomic<bool> m_emitSuppressed;
 #ifdef TRACY_ON_DEMAND
     std::atomic<uint64_t> m_connectionId;
     std::atomic<bool> m_symbolsBusy;

--- a/public/client/TracyScoped.hpp
+++ b/public/client/TracyScoped.hpp
@@ -30,11 +30,7 @@ public:
     ScopedZone& operator=( ScopedZone&& ) = delete;
 
     tracy_force_inline ScopedZone( const SourceLocationData* srcloc, int32_t depth = -1, bool is_active = true )
-#ifdef TRACY_ON_DEMAND
-        : m_active( is_active && GetProfiler().IsConnected() )
-#else
-        : m_active( is_active )
-#endif
+        : m_active( is_active && !GetProfiler().IsEmitSuppressed() )
     {
         if( !m_active ) return;
 #ifdef TRACY_ON_DEMAND
@@ -53,11 +49,7 @@ public:
     }
 
     tracy_force_inline ScopedZone( uint32_t line, const char* source, size_t sourceSz, const char* function, size_t functionSz, const char* name, size_t nameSz, uint32_t color, int32_t depth = -1, bool is_active = true )
-#ifdef TRACY_ON_DEMAND
-        : m_active( is_active && GetProfiler().IsConnected() )
-#else
-        : m_active( is_active )
-#endif
+        : m_active( is_active && !GetProfiler().IsEmitSuppressed() )
     {
         if( !m_active ) return;
 #ifdef TRACY_ON_DEMAND

--- a/public/client/TracySysTrace.cpp
+++ b/public/client/TracySysTrace.cpp
@@ -85,9 +85,7 @@ static t_GetThreadDescription _GetThreadDescription = 0;
 
 void WINAPI EventRecordCallback( PEVENT_RECORD record )
 {
-#ifdef TRACY_ON_DEMAND
-    if( !GetProfiler().IsConnected() ) return;
-#endif
+    if( GetProfiler().IsEmitSuppressed() ) return;
 
     const auto& hdr = record->EventHeader;
     // WARN: doing a fast switch-match below with the top 32 bits of the GUID
@@ -1118,8 +1116,7 @@ void SysTraceWorker( void* ptr )
     for( int i=0; i<numBuffers; i++ ) ringArray[i].Enable();
     for(;;)
     {
-#ifdef TRACY_ON_DEMAND
-        if( !GetProfiler().IsConnected() )
+        if( GetProfiler().IsEmitSuppressed() )
         {
             if( !traceActive.load( std::memory_order_relaxed ) ) break;
             for( int i=0; i<numBuffers; i++ )
@@ -1137,7 +1134,6 @@ void SysTraceWorker( void* ptr )
             std::this_thread::sleep_for( std::chrono::milliseconds( 10 ) );
             continue;
         }
-#endif
 
         bool hadData = false;
         for( int i=0; i<ctxBufferIdx; i++ )

--- a/public/tracy/TracyTTDevice.hpp
+++ b/public/tracy/TracyTTDevice.hpp
@@ -112,6 +112,9 @@ namespace tracy {
             m_frequency = frequency;
             m_tgpu = tgpu;
             if (tcpu == 0) tcpu = m_tcpu;
+            if (tracy::GetProfiler().IsEmitSuppressed()) {
+                return;
+            }
 
             auto item = Profiler::QueueSerial();
             MemWrite( &item->hdr.type, QueueType::GpuCalibration );
@@ -201,6 +204,9 @@ namespace tracy {
         }
 
         void PushStartMarker(const TTDeviceMarker& marker) {
+            if (tracy::GetProfiler().IsEmitSuppressed()) {
+                return;
+            }
             const auto queryId = this->NextQueryId(EventInfo{marker, EventPhase::Begin});
             const std::string run_id_string = this->getRunIdString(marker);
 
@@ -234,6 +240,9 @@ namespace tracy {
         }
 
         void PushEndMarker(const TTDeviceMarker& marker) {
+            if (tracy::GetProfiler().IsEmitSuppressed()) {
+                return;
+            }
             const auto queryId = this->NextQueryId(EventInfo{marker, EventPhase::End});
 
             auto zoneEnd = Profiler::QueueSerial();


### PR DESCRIPTION
Implements tenstorrent/tt-metal#49766.

Without a server connected, the client never drains its queue, so long unwatched runs grow host memory unboundedly. This adds a grace window: if no server connects within it, emission is suppressed at every producer and the buffered backlog is freed, so memory plateaus. Connecting within the window still yields full history; connecting after loses pre-connection data.

Configurable via TRACY_CONNECT_TIMEOUT (seconds, default 180; 0 disables).
