### PR TITLE
adding the .gitignore rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vs
+.vscode/settings.json
 _build
 _compiler
 tools/*


### PR DESCRIPTION
I've just found "git status" reports vscode settings file, which is often edited by extensions and personal developer stuff.
Adding the rule to ignore it. Let me know if this is not OK for some reason.