### PR TITLE
Dlukic/persisting cores selection

### DIFF
--- a/profiler/CMakeLists.txt
+++ b/profiler/CMakeLists.txt
@@ -59,6 +59,7 @@ set(SERVER_FILES
     TracyBadVersion.cpp
     TracyColor.cpp
     TracyConfig.cpp
+    TracyCoreSelection.cpp
     TracyDisassembly.cpp
     TracyEmbed.cpp
     TracyEventDebug.cpp

--- a/profiler/src/profiler/TracyCoreSelection.cpp
+++ b/profiler/src/profiler/TracyCoreSelection.cpp
@@ -40,28 +40,35 @@ static std::string DisplayName( const std::string& fileName )
     return name;
 }
 
+std::string DirPath()
+{
+    // The directory selections live in is the directory of LatestPath().
+    std::string dir = LatestPath();
+    const size_t slash = dir.find_last_of( '/' );
+    if( slash == std::string::npos ) return std::string();
+    dir.erase( slash );
+    return dir;
+}
+
 std::vector<std::pair<std::string, std::string>> List()
 {
     std::vector<std::pair<std::string, std::string>> res;
 
-    // The directory selections live in is the directory of LatestPath().
-    std::string dir = LatestPath();
-    const size_t slash = dir.find_last_of( '/' );
-    if( slash == std::string::npos ) return res;
-    dir.erase( slash + 1 );
+    const std::string dir = DirPath();
+    if( dir.empty() ) return res;
 
     const size_t extLen = strlen( Extension );
 
 #ifdef _WIN32
     WIN32_FIND_DATAA fd;
-    HANDLE h = FindFirstFileA( ( dir + "*" + Extension ).c_str(), &fd );
+    HANDLE h = FindFirstFileA( ( dir + "/*" + Extension ).c_str(), &fd );
     if( h != INVALID_HANDLE_VALUE )
     {
         do
         {
             if( fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY ) continue;
             const std::string fn = fd.cFileName;
-            res.emplace_back( DisplayName( fn ), dir + fn );
+            res.emplace_back( DisplayName( fn ), dir + "/" + fn );
         }
         while( FindNextFileA( h, &fd ) );
         FindClose( h );
@@ -74,7 +81,7 @@ std::vector<std::pair<std::string, std::string>> List()
             const std::string fn = e->d_name;
             if( fn.size() < extLen ) continue;
             if( fn.compare( fn.size() - extLen, extLen, Extension ) != 0 ) continue;
-            res.emplace_back( DisplayName( fn ), dir + fn );
+            res.emplace_back( DisplayName( fn ), dir + "/" + fn );
         }
         closedir( d );
     }

--- a/profiler/src/profiler/TracyCoreSelection.cpp
+++ b/profiler/src/profiler/TracyCoreSelection.cpp
@@ -1,5 +1,12 @@
+#include <algorithm>
 #include <stdio.h>
 #include <string.h>
+
+#ifdef _WIN32
+#  include <windows.h>
+#else
+#  include <dirent.h>
+#endif
 
 #include "TracyCoreSelection.hpp"
 #include "TracyStorage.hpp"
@@ -7,9 +14,74 @@
 namespace tracy::CoreSelection
 {
 
+static constexpr const char* Extension = ".coresel";
+
 const char* LatestPath()
 {
-    return GetSavePath( "coreselection-latest" );
+    return GetSavePath( "coreselection-latest.coresel" );
+}
+
+// Turn a file name into a friendly display label: drop the ".coresel"
+// extension and the internal "coreselection-" prefix (used by the auto-save).
+static std::string DisplayName( const std::string& fileName )
+{
+    std::string name = fileName;
+    const size_t extLen = strlen( Extension );
+    if( name.size() >= extLen && name.compare( name.size() - extLen, extLen, Extension ) == 0 )
+    {
+        name.erase( name.size() - extLen );
+    }
+    const char* prefix = "coreselection-";
+    const size_t prefixLen = strlen( prefix );
+    if( name.compare( 0, prefixLen, prefix ) == 0 )
+    {
+        name.erase( 0, prefixLen );
+    }
+    return name;
+}
+
+std::vector<std::pair<std::string, std::string>> List()
+{
+    std::vector<std::pair<std::string, std::string>> res;
+
+    // The directory selections live in is the directory of LatestPath().
+    std::string dir = LatestPath();
+    const size_t slash = dir.find_last_of( '/' );
+    if( slash == std::string::npos ) return res;
+    dir.erase( slash + 1 );
+
+    const size_t extLen = strlen( Extension );
+
+#ifdef _WIN32
+    WIN32_FIND_DATAA fd;
+    HANDLE h = FindFirstFileA( ( dir + "*" + Extension ).c_str(), &fd );
+    if( h != INVALID_HANDLE_VALUE )
+    {
+        do
+        {
+            if( fd.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY ) continue;
+            const std::string fn = fd.cFileName;
+            res.emplace_back( DisplayName( fn ), dir + fn );
+        }
+        while( FindNextFileA( h, &fd ) );
+        FindClose( h );
+    }
+#else
+    if( DIR* d = opendir( dir.c_str() ) )
+    {
+        while( dirent* e = readdir( d ) )
+        {
+            const std::string fn = e->d_name;
+            if( fn.size() < extLen ) continue;
+            if( fn.compare( fn.size() - extLen, extLen, Extension ) != 0 ) continue;
+            res.emplace_back( DisplayName( fn ), dir + fn );
+        }
+        closedir( d );
+    }
+#endif
+
+    std::sort( res.begin(), res.end(), []( const auto& a, const auto& b ) { return a.first < b.first; } );
+    return res;
 }
 
 bool Save( const char* path, const std::unordered_set<std::string>& labels )

--- a/profiler/src/profiler/TracyCoreSelection.cpp
+++ b/profiler/src/profiler/TracyCoreSelection.cpp
@@ -1,0 +1,44 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "TracyCoreSelection.hpp"
+#include "TracyStorage.hpp"
+
+namespace tracy::CoreSelection
+{
+
+const char* LatestPath()
+{
+    return GetSavePath( "coreselection-latest" );
+}
+
+bool Save( const char* path, const std::unordered_set<std::string>& labels )
+{
+    FILE* f = fopen( path, "wb" );
+    if( !f ) return false;
+    for( auto& l : labels )
+    {
+        fwrite( l.c_str(), 1, l.size(), f );
+        fputc( '\n', f );
+    }
+    fclose( f );
+    return true;
+}
+
+bool Load( const char* path, std::unordered_set<std::string>& labels )
+{
+    FILE* f = fopen( path, "rb" );
+    if( !f ) return false;
+    labels.clear();
+    char line[4096];
+    while( fgets( line, sizeof( line ), f ) )
+    {
+        size_t len = strlen( line );
+        while( len > 0 && ( line[len-1] == '\n' || line[len-1] == '\r' ) ) line[--len] = '\0';
+        if( len > 0 ) labels.emplace( line, len );
+    }
+    fclose( f );
+    return true;
+}
+
+}

--- a/profiler/src/profiler/TracyCoreSelection.hpp
+++ b/profiler/src/profiler/TracyCoreSelection.hpp
@@ -3,6 +3,8 @@
 
 #include <string>
 #include <unordered_set>
+#include <utility>
+#include <vector>
 
 namespace tracy::CoreSelection
 {
@@ -11,9 +13,17 @@ namespace tracy::CoreSelection
 // on the timeline. It is persisted as a newline-separated text file so that it
 // is portable across traces (a selection made on one chip can be loaded for
 // another) and easy to inspect by hand.
+//
+// Selections are stored in the global tracy config dir with a ".coresel"
+// extension so that previously saved selections can be listed and picked
+// directly, without going through a file dialog.
 
 // Path to the auto-saved "latest" selection in the global tracy config dir.
 const char* LatestPath();
+
+// Selection files discoverable in the global tracy config dir, as
+// {display name, full path} pairs sorted by display name.
+std::vector<std::pair<std::string, std::string>> List();
 
 bool Save( const char* path, const std::unordered_set<std::string>& labels );
 bool Load( const char* path, std::unordered_set<std::string>& labels );

--- a/profiler/src/profiler/TracyCoreSelection.hpp
+++ b/profiler/src/profiler/TracyCoreSelection.hpp
@@ -21,6 +21,10 @@ namespace tracy::CoreSelection
 // Path to the auto-saved "latest" selection in the global tracy config dir.
 const char* LatestPath();
 
+// The directory selection files are stored in (no trailing slash). This is
+// where file dialogs should default to and where List() searches.
+std::string DirPath();
+
 // Selection files discoverable in the global tracy config dir, as
 // {display name, full path} pairs sorted by display name.
 std::vector<std::pair<std::string, std::string>> List();

--- a/profiler/src/profiler/TracyCoreSelection.hpp
+++ b/profiler/src/profiler/TracyCoreSelection.hpp
@@ -1,0 +1,23 @@
+#ifndef __TRACYCORESELECTION_HPP__
+#define __TRACYCORESELECTION_HPP__
+
+#include <string>
+#include <unordered_set>
+
+namespace tracy::CoreSelection
+{
+
+// A "core selection" is simply the set of GPU context labels that are visible
+// on the timeline. It is persisted as a newline-separated text file so that it
+// is portable across traces (a selection made on one chip can be loaded for
+// another) and easy to inspect by hand.
+
+// Path to the auto-saved "latest" selection in the global tracy config dir.
+const char* LatestPath();
+
+bool Save( const char* path, const std::unordered_set<std::string>& labels );
+bool Load( const char* path, std::unordered_set<std::string>& labels );
+
+}
+
+#endif

--- a/profiler/src/profiler/TracyFileselector.cpp
+++ b/profiler/src/profiler/TracyFileselector.cpp
@@ -50,7 +50,7 @@ extern "C" int nativeOpenFile()
 }
 #endif
 
-static bool OpenFileImpl( const char* ext, const char* desc, const std::function<void(const char*)>& callback )
+static bool OpenFileImpl( const char* ext, const char* desc, const std::function<void(const char*)>& callback, const char* defaultPath )
 {
 #ifndef TRACY_NO_FILESELECTOR
 #  ifdef __EMSCRIPTEN__
@@ -77,7 +77,7 @@ static bool OpenFileImpl( const char* ext, const char* desc, const std::function
 #  else
     nfdu8filteritem_t filter = { desc, ext };
     nfdu8char_t* fn;
-    const auto res = NFD_OpenDialogU8( &fn, &filter, 1, nullptr );
+    const auto res = NFD_OpenDialogU8( &fn, &filter, 1, defaultPath );
     if( res == NFD_OKAY )
     {
         callback( (const char*)fn );
@@ -93,12 +93,12 @@ static bool OpenFileImpl( const char* ext, const char* desc, const std::function
     return false;
 }
 
-static bool SaveFileImpl( const char* ext, const char* desc, const std::function<void(const char*)>& callback )
+static bool SaveFileImpl( const char* ext, const char* desc, const std::function<void(const char*)>& callback, const char* defaultPath )
 {
 #if !defined TRACY_NO_FILESELECTOR && !defined __EMSCRIPTEN__
     nfdu8filteritem_t filter = { desc, ext };
     nfdu8char_t* fn;
-    const auto res = NFD_SaveDialogU8( &fn, &filter, 1, nullptr, nullptr );
+    const auto res = NFD_SaveDialogU8( &fn, &filter, 1, defaultPath, nullptr );
     if( res == NFD_OKAY )
     {
         callback( (const char*)fn );
@@ -113,14 +113,14 @@ static bool SaveFileImpl( const char* ext, const char* desc, const std::function
     return false;
 }
 
-void OpenFile( const char* ext, const char* desc, const std::function<void(const char*)>& callback )
+void OpenFile( const char* ext, const char* desc, const std::function<void(const char*)>& callback, const char* defaultPath )
 {
-    if( !OpenFileImpl( ext, desc, callback ) ) s_hasFailed = true;
+    if( !OpenFileImpl( ext, desc, callback, defaultPath ) ) s_hasFailed = true;
 }
 
-void SaveFile( const char* ext, const char* desc, const std::function<void(const char*)>& callback )
+void SaveFile( const char* ext, const char* desc, const std::function<void(const char*)>& callback, const char* defaultPath )
 {
-    if( !SaveFileImpl( ext, desc, callback ) ) s_hasFailed = true;
+    if( !SaveFileImpl( ext, desc, callback, defaultPath ) ) s_hasFailed = true;
 }
 
 }

--- a/profiler/src/profiler/TracyFileselector.hpp
+++ b/profiler/src/profiler/TracyFileselector.hpp
@@ -10,8 +10,8 @@ void Init();
 void Shutdown();
 bool HasFailed();
 
-void OpenFile( const char* ext, const char* desc, const std::function<void(const char*)>& callback );
-void SaveFile( const char* ext, const char* desc, const std::function<void(const char*)>& callback );
+void OpenFile( const char* ext, const char* desc, const std::function<void(const char*)>& callback, const char* defaultPath = nullptr );
+void SaveFile( const char* ext, const char* desc, const std::function<void(const char*)>& callback, const char* defaultPath = nullptr );
 
 }
 

--- a/profiler/src/profiler/TracyView.cpp
+++ b/profiler/src/profiler/TracyView.cpp
@@ -14,6 +14,7 @@
 #include "imgui.h"
 
 #include "TracyConfig.hpp"
+#include "TracyCoreSelection.hpp"
 #include "TracyFileRead.hpp"
 #include "TracyFilesystem.hpp"
 #include "TracyImGui.hpp"
@@ -110,6 +111,7 @@ View::View( void(*cbMainThread)(const std::function<void()>&, bool), FileRead& f
     m_userData.LoadState( m_vd );
     m_userData.LoadAnnotations( m_annotations );
     m_sourceRegexValid = m_userData.LoadSourceSubstitutions( m_sourceSubstitutions );
+    LoadGpuSelection( CoreSelection::LatestPath() );
 
     if( m_worker.GetCallstackSampleCount() == 0 ) m_showAllSymbols = true;
 
@@ -123,6 +125,8 @@ View::~View()
     m_userData.SaveState( m_vd );
     m_userData.SaveAnnotations( m_annotations );
     m_userData.SaveSourceSubstitutions( m_sourceSubstitutions );
+
+    if( !m_worker.GetGpuData().empty() ) SaveGpuSelection( CoreSelection::LatestPath() );
 
     if( m_compare.loadThread.joinable() ) m_compare.loadThread.join();
     if( m_saveThread.joinable() ) m_saveThread.join();

--- a/profiler/src/profiler/TracyView.hpp
+++ b/profiler/src/profiler/TracyView.hpp
@@ -7,8 +7,10 @@
 #include <functional>
 #include <memory>
 #include <nlohmann/json.hpp>
+#include <optional>
 #include <string>
 #include <thread>
+#include <unordered_set>
 #include <vector>
 
 #include "imgui.h"
@@ -294,6 +296,11 @@ private:
     void DrawPlotPoint( const ImVec2& wpos, float x, float y, int offset, uint32_t color, bool hover, double val, PlotValueFormatting format, float PlotHeight );
     void DrawOptions();
     const char* GetGpuContextLabel( const GpuCtxData* gpu );
+    std::unordered_set<std::string> CollectVisibleGpuSelection();
+    void ApplyGpuSelection( const std::unordered_set<std::string>& sel );
+    void ApplyPendingGpuSelection();
+    void SaveGpuSelection( const char* path );
+    void LoadGpuSelection( const char* path );
     void DrawMessages();
     void DrawMessageLine( const MessageData& msg, bool hasCallstack, int& idx );
     void DrawFindZone();
@@ -551,6 +558,8 @@ private:
     };
     MessageFilter m_messageFilter;
     char m_gpuFilterBuf[256] = {};
+    // GPU core selection loaded from disk, applied once the timeline items exist.
+    std::optional<std::unordered_set<std::string>> m_pendingGpuSelection;
     bool m_showMessageImages = false;
     int m_visibleMessages = 0;
     int m_messagesPerSeverity[(size_t)MessageSeverity::COUNT] = {};

--- a/profiler/src/profiler/TracyView_Options.cpp
+++ b/profiler/src/profiler/TracyView_Options.cpp
@@ -383,18 +383,31 @@ void View::DrawOptions()
 
 #ifndef TRACY_NO_FILESELECTOR
             ImGui::SameLine();
-            if( ImGui::SmallButton( ICON_FA_FLOPPY_DISK " Save selection" ) )
+            if( ImGui::SmallButton( ICON_FA_FLOPPY_DISK ) )
             {
                 Fileselector::SaveFile( "coresel", "Tracy core selection", [this]( const char* fn ) {
                     SaveGpuSelection( fn );
                 } );
             }
+            if( ImGui::IsItemHovered() ) ImGui::SetTooltip( "Save core selection" );
             ImGui::SameLine();
-            if( ImGui::SmallButton( ICON_FA_FOLDER_OPEN " Load selection" ) )
+            if( ImGui::SmallButton( ICON_FA_FOLDER_OPEN ) ) ImGui::OpenPopup( "CoreSelLoad" );
+            if( ImGui::IsItemHovered() ) ImGui::SetTooltip( "Load core selection" );
+            if( ImGui::BeginPopup( "CoreSelLoad" ) )
             {
-                Fileselector::OpenFile( "coresel", "Tracy core selection", [this]( const char* fn ) {
-                    LoadGpuSelection( fn );
-                } );
+                const auto saved = CoreSelection::List();
+                for( const auto& s : saved )
+                {
+                    if( ImGui::Selectable( s.first.c_str() ) ) LoadGpuSelection( s.second.c_str() );
+                }
+                if( !saved.empty() ) ImGui::Separator();
+                if( ImGui::Selectable( ICON_FA_FOLDER_OPEN " Browse..." ) )
+                {
+                    Fileselector::OpenFile( "coresel", "Tracy core selection", [this]( const char* fn ) {
+                        LoadGpuSelection( fn );
+                    } );
+                }
+                ImGui::EndPopup();
             }
 #endif
 

--- a/profiler/src/profiler/TracyView_Options.cpp
+++ b/profiler/src/profiler/TracyView_Options.cpp
@@ -382,12 +382,14 @@ void View::DrawOptions()
 	    }
 
 #ifndef TRACY_NO_FILESELECTOR
+            const std::string coreSelDir = CoreSelection::DirPath();
+            const char* coreSelDefault = coreSelDir.empty() ? nullptr : coreSelDir.c_str();
             ImGui::SameLine();
             if( ImGui::SmallButton( ICON_FA_FLOPPY_DISK ) )
             {
                 Fileselector::SaveFile( "coresel", "Tracy core selection", [this]( const char* fn ) {
                     SaveGpuSelection( fn );
-                } );
+                }, coreSelDefault );
             }
             if( ImGui::IsItemHovered() ) ImGui::SetTooltip( "Save core selection" );
             ImGui::SameLine();
@@ -405,7 +407,7 @@ void View::DrawOptions()
                 {
                     Fileselector::OpenFile( "coresel", "Tracy core selection", [this]( const char* fn ) {
                         LoadGpuSelection( fn );
-                    } );
+                    }, coreSelDefault );
                 }
                 ImGui::EndPopup();
             }

--- a/profiler/src/profiler/TracyView_Options.cpp
+++ b/profiler/src/profiler/TracyView_Options.cpp
@@ -5,6 +5,8 @@
 #include <random>
 #include <string>
 
+#include "TracyCoreSelection.hpp"
+#include "TracyFileselector.hpp"
 #include "TracyFilesystem.hpp"
 #include "TracyImGui.hpp"
 #include "TracyMouse.hpp"
@@ -219,6 +221,50 @@ const char* View::GetGpuContextLabel( const GpuCtxData* gpu )
     return buf;
 }
 
+std::unordered_set<std::string> View::CollectVisibleGpuSelection()
+{
+    std::unordered_set<std::string> sel;
+    const auto& gpuData = m_worker.GetGpuData();
+    const auto& itemMap = m_tc.GetItemMap();
+    for( size_t i=0; i<gpuData.size(); i++ )
+    {
+        // Only contexts whose timeline item has been created have a meaningful
+        // visibility state; skip the rest.
+        auto it = itemMap.find( gpuData[i] );
+        if( it == itemMap.end() || !it->second->IsVisible() ) continue;
+        sel.emplace( GetGpuContextLabel( gpuData[i] ) );
+    }
+    return sel;
+}
+
+void View::ApplyGpuSelection( const std::unordered_set<std::string>& sel )
+{
+    const auto& gpuData = m_worker.GetGpuData();
+    for( size_t i=0; i<gpuData.size(); i++ )
+    {
+        const char* label = GetGpuContextLabel( gpuData[i] );
+        m_tc.GetItem( gpuData[i] ).SetVisible( sel.find( label ) != sel.end() );
+    }
+}
+
+void View::ApplyPendingGpuSelection()
+{
+    if( !m_pendingGpuSelection ) return;
+    ApplyGpuSelection( *m_pendingGpuSelection );
+    m_pendingGpuSelection.reset();
+}
+
+void View::SaveGpuSelection( const char* path )
+{
+    CoreSelection::Save( path, CollectVisibleGpuSelection() );
+}
+
+void View::LoadGpuSelection( const char* path )
+{
+    std::unordered_set<std::string> sel;
+    if( CoreSelection::Load( path, sel ) ) m_pendingGpuSelection = std::move( sel );
+}
+
 void View::DrawOptions()
 {
     static bool default_markers_active = false;
@@ -334,6 +380,23 @@ void View::DrawOptions()
 			m_tc.GetItem( gpuData[i] ).SetVisible( false );
 		}
 	    }
+
+#ifndef TRACY_NO_FILESELECTOR
+            ImGui::SameLine();
+            if( ImGui::SmallButton( ICON_FA_FLOPPY_DISK " Save selection" ) )
+            {
+                Fileselector::SaveFile( "coresel", "Tracy core selection", [this]( const char* fn ) {
+                    SaveGpuSelection( fn );
+                } );
+            }
+            ImGui::SameLine();
+            if( ImGui::SmallButton( ICON_FA_FOLDER_OPEN " Load selection" ) )
+            {
+                Fileselector::OpenFile( "coresel", "Tracy core selection", [this]( const char* fn ) {
+                    LoadGpuSelection( fn );
+                } );
+            }
+#endif
 
             ImGui::SetNextItemWidth( 200 * scale );
             ImGui::InputTextWithHint( "##gpufilter", ICON_FA_FILTER " Filter GPU contexts", m_gpuFilterBuf, 256 );

--- a/profiler/src/profiler/TracyView_Timeline.cpp
+++ b/profiler/src/profiler/TracyView_Timeline.cpp
@@ -370,6 +370,8 @@ void View::DrawTimeline()
         {
             m_tc.AddItem<TimelineItemGpu>( v );
         }
+        // Items now exist, so a selection loaded from disk can be applied.
+        ApplyPendingGpuSelection();
     }
     if( m_vd.drawCpuData && m_worker.HasContextSwitches() )
     {


### PR DESCRIPTION
## Description/Motivation
Adding the option in the tracy GUI to save GPU cores and zoom selection in a file and later load it.
By default, on report close, such file is autogenerated from current selection. Also, on report open, if such file exists it is used as starting selection. This allows for iterating on many code changes (of the same op for example) and opening tracy files without the need to adjust selection and zoom every time.
Load also allows picking selection files from the same folder in the tracy UI, without invoking full OS's file picker/browse.

## Notes to reviewers:
I don't know much about tracy code, apart from what Claude tells me, so I'm not sure if my change adheres to code architecture, coding guidelines and such. If any modification/restructuring is needed, let me know.